### PR TITLE
Start support for Project page templates

### DIFF
--- a/src/components/EditActionsToolbar.tsx
+++ b/src/components/EditActionsToolbar.tsx
@@ -11,6 +11,7 @@ import { Fragment, useRef} from "react";
 
 export const EditActionsToolbar = (props: {
   mdxeditorref: React.RefObject<MDXEditorMethods>,
+  reloadCallback?: (newMd:string) => void,
 }) => {
   const newFromTemplate = () => {
     if (!confirm("This will replace any work you may have unsaved.\n\nContinue?")) {
@@ -19,6 +20,9 @@ export const EditActionsToolbar = (props: {
     const mdtext = getBlogTemplateMarkdown();
     props.mdxeditorref?.current?.setMarkdown(mdtext);
     localStorage.setItem(MARKDOWN_LOCAL_STORAGE_KEY, mdtext);
+    if (props.reloadCallback) {
+      props.reloadCallback(mdtext);
+    }
   }
 
   const loadData = async (evt: React.ChangeEvent<HTMLInputElement>) => {
@@ -33,6 +37,10 @@ export const EditActionsToolbar = (props: {
     const cleanmdtext = mdtext.replace(`<usds@omb.eop.gov>`, 'usds@omb.eop.gov');
     props.mdxeditorref?.current?.setMarkdown(cleanmdtext);
     localStorage.setItem(MARKDOWN_LOCAL_STORAGE_KEY, mdtext);
+    if (props.reloadCallback) {
+      props.reloadCallback(mdtext);
+    }
+
     // setTimeout(() => {
     //   window.location.reload(); // needs some help loading cached images
     // }, 250);

--- a/src/mdxcomponents/ImageDialogCustom.tsx
+++ b/src/mdxcomponents/ImageDialogCustom.tsx
@@ -78,7 +78,7 @@ export const ImageDialogCustom: React.FC = () => {
               Click to select image from your device
             </label>
             <input type="file" {...register('file')} />
-            {filename.length? `Current: "${filename}"`: null }
+            {filename?.length ? `Current: "${filename}"`: null }
           </div>
 
           {/*<div className={styles.formField}>*/}

--- a/src/mdxcomponents/frontmatterCustom/FrontmatterCustomEditor.tsx
+++ b/src/mdxcomponents/frontmatterCustom/FrontmatterCustomEditor.tsx
@@ -13,7 +13,7 @@ import {useCellValues, usePublisher} from '@mdxeditor/gurx';
 import styles from '../../styles/mdxeditor.copy.module.css';
 import stylesCustom from '../../styles/mdxeditor.custom.module.css';
 import {Fieldset, Grid, GridContainer, Checkbox, FileInput, Label} from "@trussworks/react-uswds";
-import {BlogFrontMatterFields, CACHE_NAME, READING_WORDS_PER_MINUTE} from "../../types/commontypes.ts";
+import {FrontMatterFields, CACHE_NAME, READING_WORDS_PER_MINUTE} from "../../types/commontypes.ts";
 import {
   blogFieldsFixup,
   generateFields,
@@ -44,7 +44,7 @@ export const FrontmatterCustomEditor = ({yaml, onChange}: FrontmatterCustomEdito
   const getFrontMatterFields = () => {
     const fields = yamlToBlogFields(yaml);
     // we do some basic cleanup. We'll need to set it back?
-    fields.carousel_image = getFilnamePartOfUrlPath(fields.carousel_image);
+    fields.carousel_image = getFilnamePartOfUrlPath(fields.carousel_image) ?? "carousel_img.png";
     return fields;
   };
 
@@ -76,7 +76,7 @@ export const FrontmatterCustomEditor = ({yaml, onChange}: FrontmatterCustomEdito
   }, []);
 
   const onSubmit = React.useCallback(
-    (frontMatterFields: BlogFrontMatterFields) => {
+    (frontMatterFields: FrontMatterFields) => {
       const fixedUpFields = blogFieldsFixup(frontMatterFields);
       const yamlstr = getYamlBlogHeader(fixedUpFields);
       onChange(yamlstr);

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -3,7 +3,7 @@ import {MDXEditorMethods} from "@mdxeditor/editor";
 import {CACHE_NAME} from "./types/commontypes.ts";
 
 
-export const getFilnamePartOfUrlPath = (pathstr?: string) => pathstr?.split("/").pop() ?? "";
+export const getFilnamePartOfUrlPath = (pathstr?: string) => pathstr?.split("/")?.pop()?.split("?")[0] ?? undefined;
 
 export const forceTypeBoolean = (value: string | null | boolean): boolean | null =>
   typeof value === 'boolean' ? value : value === 'true' ? true : value === 'false' ? false : null;

--- a/src/pages/BlogEditorPage.tsx
+++ b/src/pages/BlogEditorPage.tsx
@@ -74,7 +74,7 @@ export const BlogEditorPage = () => {
 
   return (
     <Fragment>
-      <EditActionsToolbar mdxeditorref={mdxeditorref}/>
+      <EditActionsToolbar mdxeditorref={mdxeditorref} reloadCallback={(newMd) => setOldMarkdown(newMd)} />
       <MDXEditor
         ref={mdxeditorref}
         className={"grid-container"}

--- a/src/types/commontypes.ts
+++ b/src/types/commontypes.ts
@@ -12,13 +12,24 @@ export const DEFAULT_AUTHOR = "U.S. Digital Service";
 export const CACHE_NAME = "mdedit-cache-v1";
 export const MARKDOWN_LOCAL_STORAGE_KEY = "savedMarkdown";
 
-export interface BlogFrontMatterFields {
+export type ImpactStatementField = {
+  figure: string;
+  unit: string; // e.g. "%" "M"
+  description: string;
+};
+
+export interface FrontMatterFields {
   title: string;
   date: string;
   readtime_minutes: number;
   author: string;
   permalink: string;
   basename: string; // used for MD filename and image directory name
+
+  // project pages use these
+  agency: string;
+  project_url: string;
+  impact_statement: ImpactStatementField[];
 
   carousel_title: string;
   carousel_summary: string;
@@ -28,13 +39,19 @@ export interface BlogFrontMatterFields {
   tags: string[];
 }
 
-export const BLANK_BLOG_FRONTMATTER_FIELDS: BlogFrontMatterFields = {
+export const BLANK_FRONTMATTER_FIELDS: FrontMatterFields = {
   title: "",
   date: "",
   readtime_minutes: 1,
   author: DEFAULT_AUTHOR,
   permalink: "",
-  basename: "",
+  basename: "basename",
+
+  agency: "",
+  project_url: "",
+  impact_statement: [],
+
+
   carousel_title: "",
   carousel_summary: "",
   carousel_image: "",
@@ -43,13 +60,16 @@ export const BLANK_BLOG_FRONTMATTER_FIELDS: BlogFrontMatterFields = {
   tags: [],
 };
 
-export const STARTER_BLOG_FRONTMATTER_FIELDS: BlogFrontMatterFields = {
+export const STARTER_BLOG_FRONTMATTER_FIELDS: FrontMatterFields = {
   title: "New news and blog page",
   date: getShortDate(new Date().toDateString()),
   readtime_minutes: 1,
   author: DEFAULT_AUTHOR,
   permalink: "/news-and-blog/new-news-and-blog-page-tmpl7",
   basename: "new-news-and-blog-page",
+  agency: "",
+  project_url: "",
+  impact_statement: [],
   carousel_title: "New news and blog page",
   carousel_summary: `This is a blank news-and-blog page template. Click the crab icon to edit metadata. 
   Enter new content below this header preview`,


### PR DESCRIPTION
- Added frontmatter fields for agency, project_url, impact_statement
- Support diff resetting after loading new markdown or starting a new one.
- fix bug with saved images having `?` in filenames